### PR TITLE
Feat/2 implement display trait for gedcomerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ be useful, but expect ongoing development and potential breaking changes.
 * ✅ **JSON Integration** - Optional `serde` support for JSON conversion
 * ✅ **Real-World Testing** - Tested with various GEDCOM files including complex examples
 
+## Project Status
+
+🚧 **Active Development**
+
+**Phase 1: Error Handling Foundation**: [Phase 1: Error Handling Foundation](https://github.com/ge3224/ged_io/milestone/1)
+**All Progress**: [View milestones →](https://github.com/ge3224/ged_io/milestones)
+
 ## Installation
 
 Add this to your `Cargo.toml`:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+#[cfg(test)]
+use std::io;
+
 /// Represents errors that can occur during GEDCOM parsing.
 #[derive(Debug)]
 pub enum GedcomError {
@@ -32,3 +35,34 @@ impl fmt::Display for GedcomError {
 }
 
 impl std::error::Error for GedcomError {}
+
+#[test]
+fn test_parse_error_display() {
+    let err = GedcomError::ParseError {
+        line: 10,
+        message: "Unexpected token".to_string(),
+    };
+    assert_eq!(
+        format!("{err}"),
+        "Parse error at line 10: Unexpected token"
+    );
+}
+
+#[test]
+fn test_invalid_format_display() {
+    let err = GedcomError::InvalidFormat("Missing header".to_string());
+    assert_eq!(format!("{err}"), "Invalid GEDCOM format: Missing header");
+}
+
+#[test]
+fn test_io_error_display() {
+    let io_err = io::Error::new(io::ErrorKind::NotFound, "File not found");
+    let err = GedcomError::IoError(io_err);
+    assert_eq!(format!("{err}"), "IO error: File not found");
+}
+
+#[test]
+fn test_encoding_error_display() {
+    let err = GedcomError::EncodingError("Invalid UTF-8 sequence".to_string());
+    assert_eq!(format!("{err}"), "Encoding error: Invalid UTF-8 sequence");
+}


### PR DESCRIPTION
This pull request addresses Issue #2 by implementing the `std::fmt::Display` trait for the `GedcomError` enum.

The implementation ensures that all error variants provide user-friendly and descriptive messages, making it easier to understand and debug issues related to GEDCOM parsing.

### Key Changes:

- Implemented `std::fmt::Display` for `GedcomError`.
- Ensured `ParseError` includes the line number in its display output.
- Verified that all error messages are clear, actionable, and not debug-focused.
- Added comprehensive unit tests to validate the display formatting for all error variants.

This completes all tasks and meets all acceptance criteria outlined in Issue #2.
