### PR TITLE
Feat/3 implement error trait for gedcomerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ be useful, but expect ongoing development and potential breaking changes.
 
 🚧 **Active Development**
 
-**Phase 1: Error Handling Foundation**: [Phase 1: Error Handling Foundation](https://github.com/ge3224/ged_io/milestone/1)
-**All Progress**: [View milestones →](https://github.com/ge3224/ged_io/milestones)
+* **Phase 1: Error Handling Foundation**: [Phase 1: Error Handling Foundation](https://github.com/ge3224/ged_io/milestone/1)
+* **All Progress**: [View milestones →](https://github.com/ge3224/ged_io/milestones)
 
 ## Installation
 


### PR DESCRIPTION
This pull request addresses issue #3 by implementing the std::error::Error trait for the GedcomError enum.

  Changes Introduced:
   * `impl std::error::Error for GedcomError`: The trait is now implemented, providing the necessary source() method.
   * `source()` method: This method is implemented to return a reference to the underlying std::io::Error when the GedcomError is an IoError variant. For other variants, it
     returns None.
   * `impl From<std::io::Error> for GedcomError`: This conversion trait allows for direct conversion from std::io::Error to GedcomError::IoError.
   * New Test Case: test_io_error_source has been added to src/error.rs to verify that the source() method correctly returns the underlying I/O error.

  Closes #3