### PR TITLE
feat: Convert parser to return Result for error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ pub enum GedcomError {
     /// A parsing error, with the line number and a message.
     ParseError {
         /// The line number where the error occurred.
-        line: usize,
+        line: u32,
         /// The error message.
         message: String,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl<'a> Gedcom<'a> {
     ///
     /// Returns an error if the GEDCOM data is malformed.
     pub fn parse_data(&mut self) -> Result<GedcomData, GedcomError> {
-        Ok(GedcomData::new(&mut self.tokenizer, 0))
+        GedcomData::new(&mut self.tokenizer, 0)
     }
 }
 

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::{
-    parser::parse_subset,
-    parser::Parser,
+    parser::{parse_subset, Parser},
     tokenizer::{Token, Tokenizer},
     types::UserDefinedTag,
+    GedcomError,
 };
 
 /// Physical address at which a fact occurs
@@ -25,17 +25,21 @@ pub struct Address {
 }
 
 impl Address {
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Address {
+    /// Creates a new `Address` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Address, GedcomError> {
         let mut addr = Address::default();
-        addr.parse(tokenizer, level);
-        addr
+        addr.parse(tokenizer, level)?;
+        Ok(addr)
     }
 }
 
 impl Parser for Address {
     /// parse handles ADDR tag
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip ADDR tag
         tokenizer.next_token();
 
@@ -47,25 +51,36 @@ impl Parser for Address {
             tokenizer.next_token();
         }
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "CONT" | "CONC" => {
-                value.push('\n');
-                value.push_str(&tokenizer.take_line_value());
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "CONT" | "CONC" => {
+                    value.push('\n');
+                    value.push_str(&tokenizer.take_line_value());
+                }
+                "ADR1" => self.adr1 = Some(tokenizer.take_line_value()),
+                "ADR2" => self.adr2 = Some(tokenizer.take_line_value()),
+                "ADR3" => self.adr3 = Some(tokenizer.take_line_value()),
+                "CITY" => self.city = Some(tokenizer.take_line_value()),
+                "STAE" => self.state = Some(tokenizer.take_line_value()),
+                "POST" => self.post = Some(tokenizer.take_line_value()),
+                "CTRY" => self.country = Some(tokenizer.take_line_value()),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled Address Tag: {tag}"),
+                    })
+                }
             }
-            "ADR1" => self.adr1 = Some(tokenizer.take_line_value()),
-            "ADR2" => self.adr2 = Some(tokenizer.take_line_value()),
-            "ADR3" => self.adr3 = Some(tokenizer.take_line_value()),
-            "CITY" => self.city = Some(tokenizer.take_line_value()),
-            "STAE" => self.state = Some(tokenizer.take_line_value()),
-            "POST" => self.post = Some(tokenizer.take_line_value()),
-            "CTRY" => self.country = Some(tokenizer.take_line_value()),
-            _ => panic!("{} Unhandled Address Tag: {}", tokenizer.debug(), tag),
+            Ok(())
         };
-        self.custom_data = parse_subset(tokenizer, level, handle_subset);
+
+        self.custom_data = parse_subset(tokenizer, level, handle_subset)?;
 
         if !value.is_empty() {
             self.value = Some(value);
         }
+
+        Ok(())
     }
 }
 

--- a/src/types/corporation.rs
+++ b/src/types/corporation.rs
@@ -2,6 +2,7 @@ use crate::{
     parser::{parse_subset, Parser},
     tokenizer::Tokenizer,
     types::address::Address,
+    GedcomError,
 };
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
@@ -26,27 +27,42 @@ pub struct Corporation {
 }
 
 impl Corporation {
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Corporation {
+    /// Creates a new `Corporation` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Corporation, GedcomError> {
         let mut corp = Corporation::default();
-        corp.parse(tokenizer, level);
-        corp
+        corp.parse(tokenizer, level)?;
+        Ok(corp)
     }
 }
 
 impl Parser for Corporation {
     /// parse is for a CORP tag within the SOUR tag of a HEADER
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         self.value = Some(tokenizer.take_line_value());
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "ADDR" => self.address = Some(Address::new(tokenizer, level + 1)),
-            "PHON" => self.phone = Some(tokenizer.take_line_value()),
-            "EMAIL" => self.email = Some(tokenizer.take_line_value()),
-            "FAX" => self.fax = Some(tokenizer.take_line_value()),
-            "WWW" => self.website = Some(tokenizer.take_line_value()),
-            _ => panic!("{} Unhandled CORP tag: {}", tokenizer.debug(), tag),
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "ADDR" => self.address = Some(Address::new(tokenizer, level + 1)?),
+                "PHON" => self.phone = Some(tokenizer.take_line_value()),
+                "EMAIL" => self.email = Some(tokenizer.take_line_value()),
+                "FAX" => self.fax = Some(tokenizer.take_line_value()),
+                "WWW" => self.website = Some(tokenizer.take_line_value()),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled Corporation Tag: {tag}"),
+                    })
+                }
+            }
+            Ok(())
         };
-        parse_subset(tokenizer, level, handle_subset);
+
+        parse_subset(tokenizer, level, handle_subset)?;
+
+        Ok(())
     }
 }

--- a/src/types/date/change_date.rs
+++ b/src/types/date/change_date.rs
@@ -5,6 +5,7 @@ use crate::{
     parser::{parse_subset, Parser},
     tokenizer::Tokenizer,
     types::{date::Date, note::Note},
+    GedcomError,
 };
 
 /// Represents a GEDCOM `CHANGE_DATE` structure (`CHAN` tag).
@@ -30,23 +31,38 @@ pub struct ChangeDate {
 }
 
 impl ChangeDate {
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> ChangeDate {
+    /// Creates a new `ChangeDate` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<ChangeDate, GedcomError> {
         let mut date = ChangeDate::default();
-        date.parse(tokenizer, level);
-        date
+        date.parse(tokenizer, level)?;
+        Ok(date)
     }
 }
 
 impl Parser for ChangeDate {
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         tokenizer.next_token();
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "DATE" => self.date = Some(Date::new(tokenizer, level + 1)),
-            "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)),
-            _ => panic!("{} unhandled ChangeDate tag: {}", tokenizer.debug(), tag),
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
+                "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled ChangeDate Tag: {tag}"),
+                    })
+                }
+            }
+            Ok(())
         };
-        parse_subset(tokenizer, level, handle_subset);
+
+        parse_subset(tokenizer, level, handle_subset)?;
+
+        Ok(())
     }
 }

--- a/src/types/multimedia/file.rs
+++ b/src/types/multimedia/file.rs
@@ -5,6 +5,7 @@ use crate::{
     parser::{parse_subset, Parser},
     tokenizer::Tokenizer,
     types::multimedia::Format,
+    GedcomError,
 };
 
 /// `MultimediaFileRef` is a complete local or remote file reference to the auxiliary data to be
@@ -19,26 +20,36 @@ pub struct Reference {
 }
 
 impl Reference {
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Reference {
+    /// Creates a new `Reference` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Reference, GedcomError> {
         let mut file = Reference::default();
-        file.parse(tokenizer, level);
-        file
+        file.parse(tokenizer, level)?;
+        Ok(file)
     }
 }
 
 impl Parser for Reference {
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         self.value = Some(tokenizer.take_line_value());
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "TITL" => self.title = Some(tokenizer.take_line_value()),
-            "FORM" => self.form = Some(Format::new(tokenizer, level + 1)),
-            _ => panic!(
-                "{} Unhandled MultimediaFileRefn Tag: {}",
-                tokenizer.debug(),
-                tag
-            ),
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "TITL" => self.title = Some(tokenizer.take_line_value()),
+                "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled MultimediaFileRefn Tag: {tag}"),
+                    })
+                }
+            }
+            Ok(())
         };
-        parse_subset(tokenizer, level, handle_subset);
+        parse_subset(tokenizer, level, handle_subset)?;
+
+        Ok(())
     }
 }

--- a/src/types/source/text.rs
+++ b/src/types/source/text.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     parser::{parse_subset, Parser},
     tokenizer::Tokenizer,
+    GedcomError,
 };
 
 /// A verbatim copy of any description contained within the source. This indicates notes or text
@@ -18,34 +19,48 @@ pub struct Text {
 }
 
 impl Text {
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Text {
+    /// Creates a new `Text` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    #[allow(clippy::double_must_use)]
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Text, GedcomError> {
         let mut text = Text { value: None };
-        text.parse(tokenizer, level);
-        text
+        text.parse(tokenizer, level)?;
+        Ok(text)
     }
 }
 
 impl Parser for Text {
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         let mut value = String::new();
         value.push_str(&tokenizer.take_line_value());
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "CONC" => value.push_str(&tokenizer.take_line_value()),
-            "CONT" => {
-                value.push('\n');
-                value.push_str(&tokenizer.take_line_value());
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "CONC" => value.push_str(&tokenizer.take_line_value()),
+                "CONT" => {
+                    value.push('\n');
+                    value.push_str(&tokenizer.take_line_value());
+                }
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled Text Tag: {tag}"),
+                    })
+                }
             }
-            _ => panic!(
-                "{} unhandled TextFromSource tag: {}",
-                tokenizer.debug(),
-                tag
-            ),
+
+            Ok(())
         };
-        parse_subset(tokenizer, level, handle_subset);
+
+        parse_subset(tokenizer, level, handle_subset)?;
 
         if !value.is_empty() {
             self.value = Some(value);
         }
+
+        Ok(())
     }
 }

--- a/src/types/submission.rs
+++ b/src/types/submission.rs
@@ -2,6 +2,7 @@ use crate::{
     parser::{parse_subset, Parser},
     tokenizer::Tokenizer,
     types::{custom::UserDefinedTag, date::change_date::ChangeDate, note::Note, Xref},
+    GedcomError,
 };
 
 #[cfg(feature = "json")]
@@ -81,35 +82,51 @@ impl Submission {
         }
     }
 
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8, xref: Option<Xref>) -> Submission {
+    /// Creates a new `Submission` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    #[allow(clippy::double_must_use)]
+    pub fn new(
+        tokenizer: &mut Tokenizer,
+        level: u8,
+        xref: Option<Xref>,
+    ) -> Result<Submission, GedcomError> {
         let mut subn = Submission::with_xref(xref);
-        subn.parse(tokenizer, level);
-        subn
+        subn.parse(tokenizer, level)?;
+        Ok(subn)
     }
 }
 
 impl Parser for Submission {
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         tokenizer.next_token();
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "ANCE" => self.ancestor_generations = Some(tokenizer.take_line_value()),
-            "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)),
-            "DESC" => self.descendant_generations = Some(tokenizer.take_line_value()),
-            "FAMF" => self.family_file_name = Some(tokenizer.take_line_value()),
-            "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)),
-            "ORDI" => self.ordinance_process_flag = Some(tokenizer.take_line_value()),
-            "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()),
-            "SUBM" => self.submitter_ref = Some(tokenizer.take_line_value()),
-            "TEMP" => self.temple_code = Some(tokenizer.take_line_value()),
-            _ => panic!(
-                "{}, Unhandled SubmissionRecord tag: {}",
-                tokenizer.debug(),
-                tag
-            ),
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "ANCE" => self.ancestor_generations = Some(tokenizer.take_line_value()),
+                "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)?),
+                "DESC" => self.descendant_generations = Some(tokenizer.take_line_value()),
+                "FAMF" => self.family_file_name = Some(tokenizer.take_line_value()),
+                "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
+                "ORDI" => self.ordinance_process_flag = Some(tokenizer.take_line_value()),
+                "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()),
+                "SUBM" => self.submitter_ref = Some(tokenizer.take_line_value()),
+                "TEMP" => self.temple_code = Some(tokenizer.take_line_value()),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled Submission Tag: {tag}"),
+                    })
+                }
+            }
+            Ok(())
         };
-        self.custom = parse_subset(tokenizer, level, handle_subset);
+
+        self.custom = parse_subset(tokenizer, level, handle_subset)?;
+
+        Ok(())
     }
 }
 

--- a/src/types/translation.rs
+++ b/src/types/translation.rs
@@ -1,7 +1,11 @@
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
 
-use crate::{parser::parse_subset, parser::Parser, tokenizer::Tokenizer};
+use crate::{
+    parser::{parse_subset, Parser},
+    tokenizer::Tokenizer,
+    GedcomError,
+};
 
 /// Translation (tag:TRAN) is a type of TRAN for unstructured human-readable text, such as
 /// is found in NOTE and SNOTE payloads. Each NOTE-TRAN must have either a LANG substructure or a
@@ -18,24 +22,39 @@ pub struct Translation {
 }
 
 impl Translation {
-    #[must_use]
-    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Translation {
+    /// Creates a new `Translation` from a `Tokenizer`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if parsing fails.
+    #[allow(clippy::double_must_use)]
+    pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Translation, GedcomError> {
         let mut tran = Translation::default();
-        tran.parse(tokenizer, level);
-        tran
+        tran.parse(tokenizer, level)?;
+        Ok(tran)
     }
 }
 
 impl Parser for Translation {
     ///parse handles the TRAN tag
-    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) {
+    fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         self.value = Some(tokenizer.take_line_value());
 
-        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| match tag {
-            "MIME" => self.mime = Some(tokenizer.take_line_value()),
-            "LANG" => self.language = Some(tokenizer.take_line_value()),
-            _ => panic!("{} unhandled NOTE tag: {}", tokenizer.debug(), tag),
+        let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
+            match tag {
+                "MIME" => self.mime = Some(tokenizer.take_line_value()),
+                "LANG" => self.language = Some(tokenizer.take_line_value()),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unhandled Translation Tag: {tag}"),
+                    })
+                }
+            }
+            Ok(())
         };
-        parse_subset(tokenizer, level, handle_subset);
+        parse_subset(tokenizer, level, handle_subset)?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This Pull Request addresses issue #4 by refactoring the core parsing logic in
`src/parser.rs` to utilize Rust's `Result` type for error propagation. This
replaces panic-based error handling with explicit `GedcomError` returns.

### Motivation

Previously, the parser might have used `panic!` or `unwrap()` in certain error scenarios, leading to program crashes. This PR aims to:
- Improve the parser's resilience by handling errors gracefully.
- Provide more informative error messages, including line numbers, to aid in debugging malformed GEDCOM files.
- Align the parsing logic with idiomatic Rust error handling best practices.

### Changes Introduced

- **`Parser` Trait Update:** The `parse` method in the `Parser` trait now returns `Result<(), GedcomError>`, allowing for explicit error handling.
- **Error Propagation:** All potential error conditions within the parsing functions (e.g., `parse_subset`) now return `GedcomError` instead of panicking.
- **Line Number Tracking:** `GedcomError::ParseError` now includes the line number where the parsing error occurred, making it easier to pinpoint issues in
      input files.
- **Removal of `panic!` and `unwrap()`:** All instances of `panic!` and `.unwrap()` related to error conditions in `src/parser.rs` have been removed.
- **Documentation Updates:** The documentation for the `parse` method and related parsing functions has been updated to reflect the new error handling
      mechanism and the `Result` return type.

### Related Issue

Closes #4