### PR TITLE
feat: Implement robust error handling in parsing functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl<'a> Gedcom<'a> {
     /// Returns an error if the GEDCOM data is malformed.
     pub fn new(chars: Chars<'a>) -> Result<Gedcom<'a>, GedcomError> {
         let mut tokenizer = Tokenizer::new(chars);
-        tokenizer.next_token();
+        tokenizer.next_token()?;
         Ok(Gedcom { tokenizer })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ where
                     &tag_clone,
                 )?));
             }
-            Token::Level(_) => tokenizer.next_token(),
+            Token::Level(_) => tokenizer.next_token()?,
             _ => {
                 return Err(GedcomError::ParseError {
                     line: tokenizer.line,

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -41,29 +41,29 @@ impl Parser for Address {
     /// parse handles ADDR tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip ADDR tag
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let mut value = String::new();
 
         // handle value on ADDR line
         if let Token::LineValue(addr) = &tokenizer.current_token {
             value.push_str(addr);
-            tokenizer.next_token();
+            tokenizer.next_token()?;
         }
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "CONT" | "CONC" => {
                     value.push('\n');
-                    value.push_str(&tokenizer.take_line_value());
+                    value.push_str(&tokenizer.take_line_value()?);
                 }
-                "ADR1" => self.adr1 = Some(tokenizer.take_line_value()),
-                "ADR2" => self.adr2 = Some(tokenizer.take_line_value()),
-                "ADR3" => self.adr3 = Some(tokenizer.take_line_value()),
-                "CITY" => self.city = Some(tokenizer.take_line_value()),
-                "STAE" => self.state = Some(tokenizer.take_line_value()),
-                "POST" => self.post = Some(tokenizer.take_line_value()),
-                "CTRY" => self.country = Some(tokenizer.take_line_value()),
+                "ADR1" => self.adr1 = Some(tokenizer.take_line_value()?),
+                "ADR2" => self.adr2 = Some(tokenizer.take_line_value()?),
+                "ADR3" => self.adr3 = Some(tokenizer.take_line_value()?),
+                "CITY" => self.city = Some(tokenizer.take_line_value()?),
+                "STAE" => self.state = Some(tokenizer.take_line_value()?),
+                "POST" => self.post = Some(tokenizer.take_line_value()?),
+                "CTRY" => self.country = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/corporation.rs
+++ b/src/types/corporation.rs
@@ -42,15 +42,15 @@ impl Corporation {
 impl Parser for Corporation {
     /// parse is for a CORP tag within the SOUR tag of a HEADER
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "ADDR" => self.address = Some(Address::new(tokenizer, level + 1)?),
-                "PHON" => self.phone = Some(tokenizer.take_line_value()),
-                "EMAIL" => self.email = Some(tokenizer.take_line_value()),
-                "FAX" => self.fax = Some(tokenizer.take_line_value()),
-                "WWW" => self.website = Some(tokenizer.take_line_value()),
+                "PHON" => self.phone = Some(tokenizer.take_line_value()?),
+                "EMAIL" => self.email = Some(tokenizer.take_line_value()?),
+                "FAX" => self.fax = Some(tokenizer.take_line_value()?),
+                "WWW" => self.website = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -47,7 +47,7 @@ impl UserDefinedTag {
 impl Parser for UserDefinedTag {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip ahead of initial tag
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let mut has_child = false;
         loop {
@@ -69,9 +69,9 @@ impl Parser for UserDefinedTag {
                 }
                 Token::LineValue(val) => {
                     self.value = Some(val.to_string());
-                    tokenizer.next_token();
+                    tokenizer.next_token()?;
                 }
-                Token::Level(_) => tokenizer.next_token(),
+                Token::Level(_) => tokenizer.next_token()?,
                 Token::EOF => break,
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -52,11 +52,11 @@ impl Date {
 impl Parser for Date {
     /// parse handles the DATE tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "TIME" => self.time = Some(tokenizer.take_line_value()),
+                "TIME" => self.time = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/date/change_date.rs
+++ b/src/types/date/change_date.rs
@@ -45,7 +45,7 @@ impl ChangeDate {
 
 impl Parser for ChangeDate {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {

--- a/src/types/event/detail.rs
+++ b/src/types/event/detail.rs
@@ -145,25 +145,25 @@ impl std::fmt::Debug for Detail {
 
 impl Parser for Detail {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         // handle value on event line
         let mut value = String::new();
 
         if let Token::LineValue(val) = &tokenizer.current_token {
             value.push_str(val);
-            tokenizer.next_token();
+            tokenizer.next_token()?;
         }
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             let mut pointer: Option<String> = None;
             if let Token::Pointer(xref) = &tokenizer.current_token {
                 pointer = Some(xref.to_string());
-                tokenizer.next_token();
+                tokenizer.next_token()?;
             }
             match tag {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
-                "PLAC" => self.place = Some(tokenizer.take_line_value()),
+                "PLAC" => self.place = Some(tokenizer.take_line_value()?),
                 "SOUR" => self.add_citation(Citation::new(tokenizer, level + 1)?),
                 "FAMC" => self.family_link = Some(FamilyLink::new(tokenizer, level + 1, tag)?),
                 "HUSB" | "WIFE" => {
@@ -174,7 +174,7 @@ impl Parser for Detail {
                     )?);
                 }
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
-                "TYPE" => self.event_type = Some(tokenizer.take_line_value()),
+                "TYPE" => self.event_type = Some(tokenizer.take_line_value()?),
                 "OBJE" => {
                     self.add_multimedia_record(Multimedia::new(tokenizer, level + 1, pointer)?);
                 }

--- a/src/types/event/family.rs
+++ b/src/types/event/family.rs
@@ -50,11 +50,11 @@ impl FamilyEventDetail {
 
 impl Parser for FamilyEventDetail {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "AGE" => self.age = Some(tokenizer.take_line_value()),
+                "AGE" => self.age = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/header.rs
+++ b/src/types/header.rs
@@ -72,20 +72,20 @@ impl Parser for Header {
     /// <https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#HEADER>.
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip over HEAD tag name
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "GEDC" => self.gedcom = Some(HeadMeta::new(tokenizer, level + 1)?),
                 "SOUR" => self.source = Some(HeadSour::new(tokenizer, level + 1)?),
-                "DEST" => self.destination = Some(tokenizer.take_line_value()),
+                "DEST" => self.destination = Some(tokenizer.take_line_value()?),
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
-                "SUBM" => self.submitter_tag = Some(tokenizer.take_line_value()),
-                "SUBN" => self.submission_tag = Some(tokenizer.take_line_value()),
-                "FILE" => self.filename = Some(tokenizer.take_line_value()),
-                "COPR" => self.copyright = Some(tokenizer.take_continued_text(level + 1)),
+                "SUBM" => self.submitter_tag = Some(tokenizer.take_line_value()?),
+                "SUBN" => self.submission_tag = Some(tokenizer.take_line_value()?),
+                "FILE" => self.filename = Some(tokenizer.take_line_value()?),
+                "COPR" => self.copyright = Some(tokenizer.take_continued_text(level + 1)?),
                 "CHAR" => self.encoding = Some(Encoding::new(tokenizer, level + 1)?),
-                "LANG" => self.language = Some(tokenizer.take_line_value()),
+                "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 "PLAC" => self.place = Some(HeadPlac::new(tokenizer, level + 1)?),
                 _ => {

--- a/src/types/header/encoding.rs
+++ b/src/types/header/encoding.rs
@@ -32,11 +32,11 @@ impl Encoding {
 impl Parser for Encoding {
     /// parse handles the parsing of the CHARS tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "VERS" => self.version = Some(tokenizer.take_line_value()),
+                "VERS" => self.version = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/header/meta.rs
+++ b/src/types/header/meta.rs
@@ -35,18 +35,20 @@ impl Parser for HeadMeta {
     /// parse handles parsing GEDC tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip GEDC tag
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "VERS" => self.version = Some(tokenizer.take_line_value()),
-                // this is the only value that makes sense. warn them otherwise.
+                "VERS" => self.version = Some(tokenizer.take_line_value()?),
                 "FORM" => {
-                    let form = tokenizer.take_line_value();
-                    if &form.to_uppercase() != "LINEAGE-LINKED" {
-                        println!(
-                        "WARNING: Unrecognized GEDCOM form. Expected LINEAGE-LINKED, found {form}"
-                    );
+                    let form = tokenizer.take_line_value()?;
+                    if form.to_uppercase() != "LINEAGE-LINKED" {
+                        return Err(GedcomError::ParseError {
+                            line: tokenizer.line,
+                            message: format!(
+                                "Unrecognized GEDCOM form. Expected LINEAGE-LINKED, found {form}"
+                            ),
+                        });
                     }
                     self.form = Some(form);
                 }

--- a/src/types/header/place.rs
+++ b/src/types/header/place.rs
@@ -52,12 +52,12 @@ impl Parser for HeadPlac {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // In the header, PLAC should have no payload. See
         // https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#HEAD-PLAC
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "FORM" => {
-                    let form = tokenizer.take_line_value();
+                    let form = tokenizer.take_line_value()?;
                     let jurisdictional_titles = form.split(',');
 
                     for t in jurisdictional_titles {

--- a/src/types/header/source.rs
+++ b/src/types/header/source.rs
@@ -44,12 +44,12 @@ impl HeadSour {
 impl Parser for HeadSour {
     /// parse handles the SOUR tag in a header
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "VERS" => self.version = Some(tokenizer.take_line_value()),
-                "NAME" => self.name = Some(tokenizer.take_line_value()),
+                "VERS" => self.version = Some(tokenizer.take_line_value()?),
+                "NAME" => self.name = Some(tokenizer.take_line_value()?),
                 "CORP" => self.corporation = Some(Corporation::new(tokenizer, level + 1)?),
                 "DATA" => self.data = Some(HeadSourData::new(tokenizer, level + 1)?),
                 _ => {

--- a/src/types/header/source/data.rs
+++ b/src/types/header/source/data.rs
@@ -38,12 +38,12 @@ impl HeadSourData {
 impl Parser for HeadSourData {
     /// parse parses the DATA tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
-                "COPR" => self.copyright = Some(tokenizer.take_continued_text(level + 1)),
+                "COPR" => self.copyright = Some(tokenizer.take_continued_text(level + 1)?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/individual.rs
+++ b/src/types/individual.rs
@@ -117,7 +117,7 @@ impl Parser for Individual {
         level: u8,
     ) -> Result<(), GedcomError> {
         // skip over INDI tag name
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {

--- a/src/types/individual/gender.rs
+++ b/src/types/individual/gender.rs
@@ -66,7 +66,7 @@ impl Gender {
 
 impl Parser for Gender {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         if let Token::LineValue(gender_string) = &tokenizer.current_token {
             self.value = match gender_string.as_str() {
@@ -74,19 +74,19 @@ impl Parser for Gender {
                 "F" => GenderType::Female,
                 "X" => GenderType::Nonbinary,
                 "U" => GenderType::Unknown,
-                _ => panic!(
-                    "{} Unknown gender value {} ({})",
-                    tokenizer.debug(),
-                    gender_string,
-                    level
-                ),
+                _ => {
+                    return Err(GedcomError::ParseError {
+                        line: tokenizer.line,
+                        message: format!("Unknown gender value {gender_string}"),
+                    })
+                }
             };
-            tokenizer.next_token();
+            tokenizer.next_token()?;
         }
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "FACT" => self.fact = Some(tokenizer.take_continued_text(level + 1)),
+                "FACT" => self.fact = Some(tokenizer.take_continued_text(level + 1)?),
                 "SOUR" => self.add_source_citation(Citation::new(tokenizer, level + 1)?),
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/individual/name.rs
+++ b/src/types/individual/name.rs
@@ -60,15 +60,15 @@ impl Name {
 
 impl Parser for Name {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "GIVN" => self.given = Some(tokenizer.take_line_value()),
-                "NPFX" => self.prefix = Some(tokenizer.take_line_value()),
-                "NSFX" => self.suffix = Some(tokenizer.take_line_value()),
-                "SPFX" => self.surname_prefix = Some(tokenizer.take_line_value()),
-                "SURN" => self.surname = Some(tokenizer.take_line_value()),
+                "GIVN" => self.given = Some(tokenizer.take_line_value()?),
+                "NPFX" => self.prefix = Some(tokenizer.take_line_value()?),
+                "NSFX" => self.suffix = Some(tokenizer.take_line_value()?),
+                "SPFX" => self.surname_prefix = Some(tokenizer.take_line_value()?),
+                "SURN" => self.surname = Some(tokenizer.take_line_value()?),
                 "SOUR" => self.add_source_citation(Citation::new(tokenizer, level + 1)?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 _ => {

--- a/src/types/multimedia.rs
+++ b/src/types/multimedia.rs
@@ -76,18 +76,18 @@ impl Multimedia {
 impl Parser for Multimedia {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip current line
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "FILE" => self.file = Some(Reference::new(tokenizer, level + 1)?),
                 "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
-                "TITL" => self.title = Some(tokenizer.take_line_value()),
+                "TITL" => self.title = Some(tokenizer.take_line_value()?),
                 "REFN" => {
                     self.user_reference_number =
                         Some(UserReferenceNumber::new(tokenizer, level + 1)?);
                 }
-                "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()),
+                "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()?),
                 "NOTE" => self.note_structure = Some(Note::new(tokenizer, level + 1)?),
                 "SOUR" => self.source_citation = Some(Citation::new(tokenizer, level + 1)?),
                 "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)?),

--- a/src/types/multimedia/file.rs
+++ b/src/types/multimedia/file.rs
@@ -34,10 +34,10 @@ impl Reference {
 
 impl Parser for Reference {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "TITL" => self.title = Some(tokenizer.take_line_value()),
+                "TITL" => self.title = Some(tokenizer.take_line_value()?),
                 "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/multimedia/format.rs
+++ b/src/types/multimedia/format.rs
@@ -36,11 +36,11 @@ impl Format {
 
 impl Parser for Format {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "TYPE" => self.source_media_type = Some(tokenizer.take_line_value()),
+                "TYPE" => self.source_media_type = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/multimedia/link.rs
+++ b/src/types/multimedia/link.rs
@@ -55,13 +55,13 @@ impl Link {
 impl Parser for Link {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip current line
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "FILE" => self.file = Some(Reference::new(tokenizer, level + 1)?),
                 "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
-                "TITL" => self.title = Some(tokenizer.take_line_value()),
+                "TITL" => self.title = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/multimedia/user.rs
+++ b/src/types/multimedia/user.rs
@@ -34,11 +34,11 @@ impl UserReferenceNumber {
 
 impl Parser for UserReferenceNumber {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "TYPE" => self.user_reference_type = Some(tokenizer.take_line_value()),
+                "TYPE" => self.user_reference_type = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/note.rs
+++ b/src/types/note.rs
@@ -62,12 +62,12 @@ impl Note {
 impl Parser for Note {
     /// parse handles the NOTE tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_continued_text(level));
+        self.value = Some(tokenizer.take_continued_text(level)?);
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "MIME" => self.mime = Some(tokenizer.take_line_value()),
+                "MIME" => self.mime = Some(tokenizer.take_line_value()?),
                 "TRANS" => self.translation = Some(Translation::new(tokenizer, level + 1)?),
-                "LANG" => self.language = Some(tokenizer.take_line_value()),
+                "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/repository.rs
+++ b/src/types/repository.rs
@@ -54,11 +54,11 @@ impl Parser for Repository {
         level: u8,
     ) -> Result<(), GedcomError> {
         // skip REPO tag
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "NAME" => self.name = Some(tokenizer.take_line_value()),
+                "NAME" => self.name = Some(tokenizer.take_line_value()?),
                 "ADDR" => self.address = Some(Address::new(tokenizer, level + 1)?),
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/repository/citation.rs
+++ b/src/types/repository/citation.rs
@@ -32,7 +32,7 @@ impl Citation {
     ///
     /// This function will return an error if parsing fails.
     pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Citation, GedcomError> {
-        let xref = tokenizer.take_line_value();
+        let xref = tokenizer.take_line_value()?;
         let mut rc = Citation::with_xref(xref);
         rc.parse(tokenizer, level)?;
         Ok(rc)
@@ -43,7 +43,7 @@ impl Parser for Citation {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "CALN" => self.call_number = Some(tokenizer.take_line_value()),
+                "CALN" => self.call_number = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/source.rs
+++ b/src/types/source.rs
@@ -78,36 +78,36 @@ impl Source {
 impl Parser for Source {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip SOUR tag
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             let mut pointer: Option<String> = None;
             if let Token::Pointer(xref) = &tokenizer.current_token {
                 pointer = Some(xref.to_string());
-                tokenizer.next_token();
+                tokenizer.next_token()?;
             }
             match tag {
-                "DATA" => tokenizer.next_token(),
+                "DATA" => tokenizer.next_token()?,
                 "EVEN" => {
-                    let events_recorded = tokenizer.take_line_value();
+                    let events_recorded = tokenizer.take_line_value()?;
                     let mut event = Detail::new(tokenizer, level + 2, "OTHER")?;
                     event.with_source_data(events_recorded);
                     self.data.add_event(event);
                     return Ok(());
                 }
-                "AGNC" => self.data.agency = Some(tokenizer.take_line_value()),
-                "ABBR" => self.abbreviation = Some(tokenizer.take_continued_text(level + 1)),
+                "AGNC" => self.data.agency = Some(tokenizer.take_line_value()?),
+                "ABBR" => self.abbreviation = Some(tokenizer.take_continued_text(level + 1)?),
                 "CHAN" => self.change_date = Some(Box::new(ChangeDate::new(tokenizer, level + 1)?)),
-                "TITL" => self.title = Some(tokenizer.take_continued_text(level + 1)),
-                "AUTH" => self.author = Some(tokenizer.take_continued_text(level + 1)),
-                "PUBL" => self.publication_facts = Some(tokenizer.take_continued_text(level + 1)),
+                "TITL" => self.title = Some(tokenizer.take_continued_text(level + 1)?),
+                "AUTH" => self.author = Some(tokenizer.take_continued_text(level + 1)?),
+                "PUBL" => self.publication_facts = Some(tokenizer.take_continued_text(level + 1)?),
                 "TEXT" => {
-                    self.citation_from_source = Some(tokenizer.take_continued_text(level + 1));
+                    self.citation_from_source = Some(tokenizer.take_continued_text(level + 1)?);
                 }
                 "OBJE" => self.add_multimedia(Multimedia::new(tokenizer, level + 1, pointer)?),
                 "NOTE" => self.add_note(Note::new(tokenizer, level + 1)?),
                 "REPO" => self.add_repo_citation(Citation::new(tokenizer, level + 1)?),
-                "RFN" => self.submitter_registered_rfn = Some(tokenizer.take_line_value()),
+                "RFN" => self.submitter_registered_rfn = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/source/citation.rs
+++ b/src/types/source/citation.rs
@@ -42,7 +42,7 @@ impl Citation {
     /// This function will return an error if parsing fails.
     pub fn new(tokenizer: &mut Tokenizer, level: u8) -> Result<Citation, GedcomError> {
         let mut citation = Citation {
-            xref: tokenizer.take_line_value(),
+            xref: tokenizer.take_line_value()?,
             page: None,
             data: None,
             note: None,
@@ -62,23 +62,23 @@ impl Citation {
 
 impl Parser for Citation {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             let mut pointer: Option<String> = None;
             if let Token::Pointer(xref) = &tokenizer.current_token {
                 pointer = Some(xref.to_string());
-                tokenizer.next_token();
+                tokenizer.next_token()?;
             }
             match tag {
-                "PAGE" => self.page = Some(tokenizer.take_continued_text(level + 1)),
+                "PAGE" => self.page = Some(tokenizer.take_continued_text(level + 1)?),
                 "DATA" => self.data = Some(SourceCitationData::new(tokenizer, level + 1)?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 "QUAY" => {
                     self.certainty_assessment =
                         Some(CertaintyAssessment::new(tokenizer, level + 1)?);
                 }
-                "RFN" => self.submitter_registered_rfn = Some(tokenizer.take_line_value()),
+                "RFN" => self.submitter_registered_rfn = Some(tokenizer.take_line_value()?),
                 "OBJE" => self.add_multimedia(Multimedia::new(tokenizer, level + 1, pointer)?),
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/source/citation/data.rs
+++ b/src/types/source/citation/data.rs
@@ -38,7 +38,7 @@ impl SourceCitationData {
 impl Parser for SourceCitationData {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip because this DATA tag should have now line value
-        tokenizer.next_token();
+        tokenizer.next_token()?;
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),

--- a/src/types/source/quay.rs
+++ b/src/types/source/quay.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for CertaintyAssessment {
 
 impl Parser for CertaintyAssessment {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
         if let Token::LineValue(val) = &tokenizer.current_token {
             *self = match val.as_str() {
                 "0" => CertaintyAssessment::Unreliable,
@@ -84,7 +84,7 @@ impl Parser for CertaintyAssessment {
                 ),
             });
         }
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         Ok(())
     }

--- a/src/types/source/text.rs
+++ b/src/types/source/text.rs
@@ -35,14 +35,14 @@ impl Text {
 impl Parser for Text {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         let mut value = String::new();
-        value.push_str(&tokenizer.take_line_value());
+        value.push_str(&tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "CONC" => value.push_str(&tokenizer.take_line_value()),
+                "CONC" => value.push_str(&tokenizer.take_line_value()?),
                 "CONT" => {
                     value.push('\n');
-                    value.push_str(&tokenizer.take_line_value());
+                    value.push_str(&tokenizer.take_line_value()?);
                 }
                 _ => {
                     return Err(GedcomError::ParseError {

--- a/src/types/submission.rs
+++ b/src/types/submission.rs
@@ -101,19 +101,19 @@ impl Submission {
 
 impl Parser for Submission {
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "ANCE" => self.ancestor_generations = Some(tokenizer.take_line_value()),
+                "ANCE" => self.ancestor_generations = Some(tokenizer.take_line_value()?),
                 "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)?),
-                "DESC" => self.descendant_generations = Some(tokenizer.take_line_value()),
-                "FAMF" => self.family_file_name = Some(tokenizer.take_line_value()),
+                "DESC" => self.descendant_generations = Some(tokenizer.take_line_value()?),
+                "FAMF" => self.family_file_name = Some(tokenizer.take_line_value()?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
-                "ORDI" => self.ordinance_process_flag = Some(tokenizer.take_line_value()),
-                "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()),
-                "SUBM" => self.submitter_ref = Some(tokenizer.take_line_value()),
-                "TEMP" => self.temple_code = Some(tokenizer.take_line_value()),
+                "ORDI" => self.ordinance_process_flag = Some(tokenizer.take_line_value()?),
+                "RIN" => self.automated_record_id = Some(tokenizer.take_line_value()?),
+                "SUBM" => self.submitter_ref = Some(tokenizer.take_line_value()?),
+                "TEMP" => self.temple_code = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/submitter.rs
+++ b/src/types/submitter.rs
@@ -79,22 +79,22 @@ impl Parser for Submitter {
     /// Parse handles SUBM top-level tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
         // skip over SUBM tag name
-        tokenizer.next_token();
+        tokenizer.next_token()?;
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             let mut pointer: Option<String> = None;
             if let Token::Pointer(xref) = &tokenizer.current_token {
                 pointer = Some(xref.to_string());
-                tokenizer.next_token();
+                tokenizer.next_token()?;
             }
             match tag {
-                "NAME" => self.name = Some(tokenizer.take_line_value()),
+                "NAME" => self.name = Some(tokenizer.take_line_value()?),
                 "ADDR" => self.address = Some(Address::new(tokenizer, level + 1)?),
                 "OBJE" => self.add_multimedia(Link::new(tokenizer, level + 1, pointer)?),
-                "LANG" => self.language = Some(tokenizer.take_line_value()),
+                "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)?),
-                "PHON" => self.phone = Some(tokenizer.take_line_value()),
+                "PHON" => self.phone = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,

--- a/src/types/translation.rs
+++ b/src/types/translation.rs
@@ -38,12 +38,12 @@ impl Translation {
 impl Parser for Translation {
     ///parse handles the TRAN tag
     fn parse(&mut self, tokenizer: &mut Tokenizer, level: u8) -> Result<(), GedcomError> {
-        self.value = Some(tokenizer.take_line_value());
+        self.value = Some(tokenizer.take_line_value()?);
 
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
-                "MIME" => self.mime = Some(tokenizer.take_line_value()),
-                "LANG" => self.language = Some(tokenizer.take_line_value()),
+                "MIME" => self.mime = Some(tokenizer.take_line_value()?),
+                "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 _ => {
                     return Err(GedcomError::ParseError {
                         line: tokenizer.line,


### PR DESCRIPTION
This pull request addresses issue #5 by refactoring the GEDCOM parsing logic to
use `GedcomError` for all internal parsing functions, replacing previous
`panic!` calls with `Result` types and the `?` operator.

**Problem:**
Previously, several parsing helper functions would `panic!` on encountering
unexpected or malformed GEDCOM data. This behavior is not ideal for a library,
as it can lead to unrecoverable crashes in applications using the library.

This PR introduces a more robust error handling mechanism by:
- Converting all relevant `new` methods and `parse` implementations across various `types` modules (e.g., `Family`, `Individual`, `Header`, `Multimedia`, `Source`, `Submission`, `Submitter`) to return `Result<T, GedcomError>`.
- Replacing all instances of `unwrap()` and `expect()` with the `?` operator for graceful error propagation, allowing callers to handle errors explicitly.
- Enhancing error messages with contextual information, including line numbers, to aid in debugging and provide clearer insights into parsing failures.
- Updating function signatures and their callers to align with the new `Result` return types, ensuring type safety and proper error handling throughout the codebase.

Closes #5