### PR TITLE
feat: support multiple NAME structures per Individual

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,37 @@
 
 This guide explains the key differences between GEDCOM 5.5.1 and GEDCOM 7.0, and how to migrate your applications using the `ged_io` library.
 
+## Unreleased
+
+### Multiple `NAME` structures per `Individual`
+
+The `Individual` struct now has a new `names: Vec<Name>` field that holds all `NAME` structures
+parsed for an individual, in source order. This aligns with GEDCOM 5.5.1 and 7.0, both of which
+allow `{0:M}` `PERSONAL_NAME_STRUCTURE` per individual.
+
+The existing `name: Option<Name>` field is unchanged — it continues to hold the **last** parsed
+name, preserving backward compatibility. When `names` is non-empty, `name` will equal the last
+element of `names`.
+
+**Migration:** Code that reads `individual.name` will continue to work unchanged. New code can
+iterate `individual.names` to access all names:
+
+```rust
+// Old (still works)
+if let Some(name) = &individual.name {
+    println!("{}", name.value.unwrap_or_default());
+}
+
+// New — iterate all names
+for name in &individual.names {
+    println!("{}", name.value.as_deref().unwrap_or(""));
+}
+```
+
+When serializing older JSON that lacks the `names` field, deserialization will produce an empty
+`Vec` (the field is marked `#[serde(default)]`). When writing GEDCOM output, the writer iterates
+`names` if populated, falling back to `name` otherwise.
+
 ## Overview
 
 GEDCOM 7.0 was released in 2021 as a significant update to the GEDCOM standard. While `ged_io` supports both versions, understanding the differences will help you make the most of the new features and ensure compatibility.

--- a/src/types.rs
+++ b/src/types.rs
@@ -232,9 +232,14 @@ impl GedcomData {
             // Direct citations on the individual
             stats.on_individuals += individual.source.len();
 
-            // Citations on name
-            if let Some(ref name) = individual.name {
+            // Citations on names
+            for name in &individual.names {
                 stats.on_names += name.source.len();
+            }
+            if individual.names.is_empty() {
+                if let Some(ref name) = individual.name {
+                    stats.on_names += name.source.len();
+                }
             }
 
             // Citations on gender
@@ -495,7 +500,15 @@ impl GedcomData {
         self.individuals
             .iter()
             .filter(|i| {
-                i.name.as_ref().is_some_and(|name| {
+                let names_to_search: Vec<&crate::types::individual::name::Name> =
+                    if !i.names.is_empty() {
+                        i.names.iter().collect()
+                    } else if let Some(ref name) = i.name {
+                        vec![name]
+                    } else {
+                        vec![]
+                    };
+                names_to_search.iter().any(|name| {
                     name.value
                         .as_ref()
                         .is_some_and(|v| v.to_lowercase().contains(&query_lower))

--- a/src/types/individual.rs
+++ b/src/types/individual.rs
@@ -47,6 +47,13 @@ use serde::{Deserialize, Serialize};
 pub struct Individual {
     pub xref: Option<Xref>,
     pub name: Option<Name>,
+    /// All `NAME` structures for this individual, in source order.
+    ///
+    /// GEDCOM 5.5.1 and 7.0 allow `{0:M}` `PERSONAL_NAME_STRUCTURE` per
+    /// individual. The [`Individual::name`] field retains only the last parsed
+    /// name for backward compatibility; `names` exposes the complete list.
+    #[cfg_attr(feature = "json", serde(default))]
+    pub names: Vec<Name>,
     pub sex: Option<Gender>,
     pub families: Vec<FamilyLink>,
     pub attributes: Vec<AttributeDetail>,
@@ -176,6 +183,11 @@ impl Individual {
         self.multimedia.push(multimedia);
     }
 
+    pub fn add_name(&mut self, name: Name) {
+        self.name = Some(name.clone());
+        self.names.push(name);
+    }
+
     pub fn add_attribute(&mut self, attribute: AttributeDetail) {
         self.attributes.push(attribute);
     }
@@ -205,7 +217,7 @@ impl Individual {
     /// ```
     #[must_use]
     pub fn full_name(&self) -> Option<String> {
-        self.name.as_ref().and_then(|n| {
+        self.names.first().or(self.name.as_ref()).and_then(|n| {
             n.value
                 .as_ref()
                 .map(|v| v.replace('/', "").trim().to_string())
@@ -215,13 +227,19 @@ impl Individual {
     /// Gets the given (first) name if available.
     #[must_use]
     pub fn given_name(&self) -> Option<&str> {
-        self.name.as_ref().and_then(|n| n.given.as_deref())
+        self.names
+            .first()
+            .or(self.name.as_ref())
+            .and_then(|n| n.given.as_deref())
     }
 
     /// Gets the surname (family name) if available.
     #[must_use]
     pub fn surname(&self) -> Option<&str> {
-        self.name.as_ref().and_then(|n| n.surname.as_deref())
+        self.names
+            .first()
+            .or(self.name.as_ref())
+            .and_then(|n| n.surname.as_deref())
     }
 
     /// Checks if the individual is male.
@@ -332,7 +350,7 @@ impl Parser for Individual {
         let handle_subset = |tag: &str, tokenizer: &mut Tokenizer| -> Result<(), GedcomError> {
             match tag {
                 // TODO handle xref
-                "NAME" => self.name = Some(Name::new(tokenizer, level + 1)?),
+                "NAME" => self.add_name(Name::new(tokenizer, level + 1)?),
                 "SEX" => self.sex = Some(Gender::new(tokenizer, level + 1)?),
                 "ADOP" | "BIRT" | "BAPM" | "BARM" | "BASM" | "BLES" | "BURI" | "CENS" | "CHR"
                 | "CHRA" | "CONF" | "CREM" | "DEAT" | "EMIG" | "FCOM" | "GRAD" | "IMMI"
@@ -591,5 +609,99 @@ mod tests {
             a_sour.note.as_ref().unwrap().value.as_ref().unwrap(),
             "A note\nNote continued here. The word TEST should not be broken!"
         );
+    }
+
+    #[test]
+    fn test_parse_multiple_names() {
+        let sample = "\
+            0 HEAD\n\
+            1 GEDC\n\
+            2 VERS 5.5\n\
+            0 @I1@ INDI\n\
+            1 NAME Mary /Smith/\n\
+            1 BIRT\n\
+            2 DATE 1 JAN 1980\n\
+            1 NAME Mary /Smith-Jones/\n\
+            1 MARR\n\
+            2 DATE 1 JUN 2005\n\
+            0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        let data = doc.parse_data().unwrap();
+
+        let indi = &data.individuals[0];
+        assert_eq!(indi.names.len(), 2);
+        assert_eq!(indi.names[0].value.as_ref().unwrap(), "Mary /Smith/");
+        assert_eq!(indi.names[1].value.as_ref().unwrap(), "Mary /Smith-Jones/");
+        assert_eq!(
+            indi.name.as_ref().unwrap().value.as_ref().unwrap(),
+            "Mary /Smith-Jones/"
+        );
+        assert_eq!(indi.name, Some(indi.names[1].clone()));
+    }
+
+    #[test]
+    fn test_parse_single_name_populates_both() {
+        let sample = "\
+            0 HEAD\n\
+            1 GEDC\n\
+            2 VERS 5.5\n\
+            0 @I1@ INDI\n\
+            1 NAME John /Doe/\n\
+            0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        let data = doc.parse_data().unwrap();
+
+        let indi = &data.individuals[0];
+        assert_eq!(indi.names.len(), 1);
+        assert_eq!(indi.names[0].value.as_ref().unwrap(), "John /Doe/");
+        assert_eq!(
+            indi.name.as_ref().unwrap().value.as_ref().unwrap(),
+            "John /Doe/"
+        );
+    }
+
+    #[test]
+    fn test_parse_zero_names() {
+        let sample = "\
+            0 HEAD\n\
+            1 GEDC\n\
+            2 VERS 5.5\n\
+            0 @I1@ INDI\n\
+            1 SEX M\n\
+            0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        let data = doc.parse_data().unwrap();
+
+        let indi = &data.individuals[0];
+        assert!(indi.names.is_empty());
+        assert!(indi.name.is_none());
+    }
+
+    #[test]
+    fn test_round_trip_multiple_names() {
+        use crate::GedcomBuilder;
+
+        let original = "\
+            0 HEAD\n\
+            1 GEDC\n\
+            2 VERS 5.5\n\
+            0 @I1@ INDI\n\
+            1 NAME Mary /Smith/\n\
+            1 NAME Mary /Smith-Jones/\n\
+            1 SEX F\n\
+            0 TRLR";
+
+        let data = GedcomBuilder::new().build_from_str(original).unwrap();
+        let writer = crate::GedcomWriter::new();
+        let written = writer.write_to_string(&data).unwrap();
+
+        let data2 = GedcomBuilder::new().build_from_str(&written).unwrap();
+        let indi = &data2.individuals[0];
+        assert_eq!(indi.names.len(), 2);
+        assert_eq!(indi.names[0].value.as_ref().unwrap(), "Mary /Smith/");
+        assert_eq!(indi.names[1].value.as_ref().unwrap(), "Mary /Smith-Jones/");
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -355,7 +355,11 @@ impl GedcomWriter {
     ) -> Result<(), io::Error> {
         self.write_line_with_xref(writer, 0, individual.xref.as_deref(), "INDI", None)?;
 
-        if let Some(ref name) = individual.name {
+        if !individual.names.is_empty() {
+            for name in &individual.names {
+                self.write_name(writer, name)?;
+            }
+        } else if let Some(ref name) = individual.name {
             self.write_name(writer, name)?;
         }
 


### PR DESCRIPTION
## Summary

Add a `names: Vec<Name>` field to `Individual` so that all `NAME` structures in an `INDI` record are preserved, rather than only retaining the last one. Existing consumers of `individual.name` continue to work unchanged.

Closes #44.

## Before

Only the final `NAME` tag within an individual record was kept. Any additional names were silently overwritten.

## After

- `Individual.names: Vec<Name>` holds every parsed `NAME` in source order
- `Individual.name: Option<Name>` still mirrors the **last** parsed name (backward-compatible)
- Writer iterates `names` when non-empty, falls back to `name` otherwise
- Convenience methods (`full_name`, `given_name`, `surname`) prefer the first entry in `names`
- Citation counting and name search now cover all names
- `#[serde(default)]` on `names` allows deserializing older JSON without the field

## Outcome

GEDCOM files with multiple `NAME` structures (permitted since GEDCOM 5.5.1) are now fully parsed and round-tripped. Issue #44 is resolved.

## Review Instructions

1. Review `src/types/individual.rs` — new field, `add_name` method, and updated `handle_subset` closure
2. Review `src/writer.rs` — `write_individual` now iterates `names` with fallback
3. Review `src/types.rs` — citation counting and name search updated
4. Check new unit tests in `individual.rs` cover: multiple names, single name, zero names, and round-trip