### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 .DS_Store
-notes.md


### PR DESCRIPTION
Resolves #48.

Within-record handlers now uniformly skip unknown standard-shaped tags instead of erroring in some records and skipping in others. Top-level dispatch (level-0 records) and lexical errors stay strict.

Configurable strictness is planned for a later release and is deliberately out of scope here — closes #49 in favor of this minimal, non-API-changing fix. Thanks to @Its-Just-Nans for flagging the inconsistency.