### PR TITLE
Handle unknown standard tags consistently inside records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 .DS_Store
-notes.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "ged_io"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "calendrical_calculations",
  "calendrier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ged_io"
-version = "0.13.0"
+version = "0.13.1"
 authors = [
     "Robert Pirtle <astropirtle@gmail.com>",
     "Jacob Benison <ge3224@gmail.com>",

--- a/src/types.rs
+++ b/src/types.rs
@@ -666,6 +666,7 @@ impl Parser for GedcomData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Gedcom;
 
     #[test]
     fn test_parse_shared_note() {
@@ -753,5 +754,18 @@ mod tests {
         let data = GedcomData::new(&mut tokenizer, 0).unwrap();
 
         assert_eq!(data.total_records(), 2); // 1 individual + 1 shared note
+    }
+
+    #[test]
+    fn test_unknown_stdtag_at_level_zero_errors() {
+        let sample = "\
+          0 HEAD\n\
+          1 GEDC\n\
+          2 VERS 5.5\n\
+          0 BLAH something\n\
+          0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        assert!(doc.parse_data().is_err());
     }
 }

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -65,10 +65,8 @@ impl Parser for Address {
                 "POST" => self.post = Some(tokenizer.take_line_value()?),
                 "CTRY" => self.country = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Address Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/corporation.rs
+++ b/src/types/corporation.rs
@@ -52,10 +52,8 @@ impl Parser for Corporation {
                 "FAX" => self.fax = Some(tokenizer.take_line_value()?),
                 "WWW" => self.website = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Corporation Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -257,10 +257,8 @@ impl Parser for Date {
                 "TIME" => self.time = Some(tokenizer.take_line_value()?),
                 "PHRASE" => self.phrase = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Date Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/date/change_date.rs
+++ b/src/types/date/change_date.rs
@@ -52,10 +52,8 @@ impl Parser for ChangeDate {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled ChangeDate Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/event/family.rs
+++ b/src/types/event/family.rs
@@ -60,10 +60,8 @@ impl Parser for FamilyEventDetail {
             match tag {
                 "AGE" => self.age = Some(Age::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled FamilyEventDetail Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/family.rs
+++ b/src/types/family.rs
@@ -225,10 +225,8 @@ impl Parser for Family {
                 // External identifier (GEDCOM 7.0)
                 "EXID" => self.external_ids.push(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Family Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/gedcom7.rs
+++ b/src/types/gedcom7.rs
@@ -85,10 +85,8 @@ impl Parser for SortDate {
                 "TIME" => self.time = Some(tokenizer.take_line_value()?),
                 "PHRASE" => self.phrase = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled SortDate Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())
@@ -143,10 +141,8 @@ impl Parser for CreationDate {
             match tag {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled CreationDate Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())
@@ -272,10 +268,8 @@ impl Parser for Crop {
                 "HEIGHT" => self.height = Some(value),
                 "WIDTH" => self.width = Some(value),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Crop Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())
@@ -384,10 +378,8 @@ impl Parser for NonEvent {
                         )?);
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled NonEvent Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/header.rs
+++ b/src/types/header.rs
@@ -211,10 +211,8 @@ impl Parser for Header {
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 "PLAC" => self.place = Some(HeadPlac::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Header Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/header/meta.rs
+++ b/src/types/header/meta.rs
@@ -52,12 +52,9 @@ impl Parser for HeadMeta {
                     }
                     self.form = Some(form);
                 }
-                // _ => panic!("{} Unhandled GEDC Tag: {}", tokenizer.debug(), tag),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled HeadMeta Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/header/place.rs
+++ b/src/types/header/place.rs
@@ -66,10 +66,8 @@ impl Parser for HeadPlac {
                     }
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled HeadPlace Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/header/schema.rs
+++ b/src/types/header/schema.rs
@@ -215,13 +215,10 @@ impl Parser for Schema {
                     if let Some(definition) = TagDefinition::from_payload(&payload) {
                         self.tag_definitions.push(definition);
                     }
-                    // Skip any substructures of TAG (none expected, but be tolerant)
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Schema Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/header/source.rs
+++ b/src/types/header/source.rs
@@ -53,10 +53,8 @@ impl Parser for HeadSour {
                 "CORP" => self.corporation = Some(Corporation::new(tokenizer, level + 1)?),
                 "DATA" => self.data = Some(HeadSourData::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled HeadSour Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/header/source/data.rs
+++ b/src/types/header/source/data.rs
@@ -45,10 +45,8 @@ impl Parser for HeadSourData {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
                 "COPR" => self.copyright = Some(tokenizer.take_continued_text(level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled HeadSourData Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/individual.rs
+++ b/src/types/individual.rs
@@ -385,10 +385,8 @@ impl Parser for Individual {
                 // External identifier (GEDCOM 7.0)
                 "EXID" => self.external_ids.push(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Individual Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/individual/association.rs
+++ b/src/types/individual/association.rs
@@ -53,10 +53,8 @@ impl Parser for Association {
                 "TYPE" => self.association_type = Some(tokenizer.take_line_value()?),
                 "NOTE" => self.note = Some(Note::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Association Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/individual/attribute/detail.rs
+++ b/src/types/individual/attribute/detail.rs
@@ -97,7 +97,7 @@ impl AttributeDetail {
     /// # Errors
     ///
     /// This function will return an error if the tag is unrecognized.
-    pub fn from_tag(tag: &str, line_number: u32) -> Result<IndividualAttribute, GedcomError> {
+    pub fn from_tag(tag: &str, _line_number: u32) -> Result<IndividualAttribute, GedcomError> {
         let attribute = match tag {
             "CAST" => IndividualAttribute::CastName,
             "DSCR" => IndividualAttribute::PhysicalDescription,
@@ -113,12 +113,9 @@ impl AttributeDetail {
             "SSN" => IndividualAttribute::SocialSecurityNumber,
             "TITL" => IndividualAttribute::NobilityTypeTitle,
             "FACT" => IndividualAttribute::Fact,
-            // _ => panic!("Unrecognized IndividualAttribute tag: {tag}"),
             _ => {
-                return Err(GedcomError::ParseError {
-                    line: line_number,
-                    message: format!("Unhandled IndividualAttribute Tag: {tag}"),
-                })
+                // the caller already filters
+                unreachable!()
             }
         };
 

--- a/src/types/individual/family_link.rs
+++ b/src/types/individual/family_link.rs
@@ -63,10 +63,8 @@ impl FamilyLink {
             "FAMC" => FamilyLinkType::Child,
             "FAMS" => FamilyLinkType::Spouse,
             _ => {
-                return Err(GedcomError::ParseError {
-                    line: tokenizer.line,
-                    message: format!("Unhandled FamilyLinkType Tag: {tag}"),
-                })
+                // The caller already filters with FAMC | FAMS before calling
+                unreachable!()
             }
         };
         let mut family_link = FamilyLink {
@@ -176,10 +174,8 @@ impl Parser for FamilyLink {
                     tokenizer.line,
                 )?,
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled FamilyLink Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/individual/gender.rs
+++ b/src/types/individual/gender.rs
@@ -89,10 +89,8 @@ impl Parser for Gender {
                 "FACT" => self.fact = Some(tokenizer.take_continued_text(level + 1)?),
                 "SOUR" => self.add_source_citation(Citation::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Gender Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/lds.rs
+++ b/src/types/lds.rs
@@ -336,10 +336,8 @@ impl Parser for LdsOrdinance {
                         .push(Citation::new(tokenizer, level + 1)?);
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled LDS Ordinance Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/multimedia.rs
+++ b/src/types/multimedia.rs
@@ -92,10 +92,8 @@ impl Parser for Multimedia {
                 "SOUR" => self.source_citation = Some(Citation::new(tokenizer, level + 1)?),
                 "CHAN" => self.change_date = Some(ChangeDate::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Multimedia Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/multimedia/file.rs
+++ b/src/types/multimedia/file.rs
@@ -53,10 +53,8 @@ impl Parser for Reference {
                 "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
                 "CROP" => self.crop = Some(Crop::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled MultimediaFileRefn Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/multimedia/format.rs
+++ b/src/types/multimedia/format.rs
@@ -42,10 +42,8 @@ impl Parser for Format {
             match tag {
                 "TYPE" => self.source_media_type = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled MultimediaFormat Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/multimedia/link.rs
+++ b/src/types/multimedia/link.rs
@@ -63,10 +63,8 @@ impl Parser for Link {
                 "FORM" => self.form = Some(Format::new(tokenizer, level + 1)?),
                 "TITL" => self.title = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Link Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/multimedia/user.rs
+++ b/src/types/multimedia/user.rs
@@ -40,10 +40,8 @@ impl Parser for UserReferenceNumber {
             match tag {
                 "TYPE" => self.user_reference_type = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled UserReferenceNumber Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/note.rs
+++ b/src/types/note.rs
@@ -69,10 +69,8 @@ impl Parser for Note {
                 "TRANS" => self.translation = Some(Translation::new(tokenizer, level + 1)?),
                 "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Note Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/place.rs
+++ b/src/types/place.rs
@@ -172,10 +172,8 @@ impl Parser for MapCoordinates {
                 "LATI" => self.latitude = Some(tokenizer.take_line_value()?),
                 "LONG" => self.longitude = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled MapCoordinates Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())
@@ -243,10 +241,8 @@ impl Parser for PlaceVariation {
             match tag {
                 "TYPE" => self.variation_type = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled PlaceVariation Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())
@@ -345,10 +341,8 @@ impl Parser for Place {
                 "SOUR" => self.citations.push(Citation::new(tokenizer, level + 1)?),
                 "EXID" => self.external_ids.push(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Place Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/shared_note.rs
+++ b/src/types/shared_note.rs
@@ -344,10 +344,8 @@ impl Parser for SharedNote {
                     self.creation_date = Some(ChangeDate::new(tokenizer, level + 1)?);
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled SharedNote Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/source.rs
+++ b/src/types/source.rs
@@ -259,4 +259,23 @@ mod tests {
 
         assert_eq!(quay.get_int().unwrap(), 1);
     }
+
+    #[test]
+    fn test_unknown_stdtag_inside_record_is_skipped() {
+        let sample = "\
+          0 HEAD\n\
+          1 GEDC\n\
+          2 VERS 5.5\n\
+          0 @S1@ SOUR\n\
+          1 TITL Real title\n\
+          1 BLAH unknown subtag value\n\
+          1 AUTH Real author\n\
+          0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        let data = doc.parse_data().unwrap();
+        let source = &data.sources[0];
+        assert_eq!(source.title.as_deref(), Some("Real title"));
+        assert_eq!(source.author.as_deref(), Some("Real author"));
+    }
 }

--- a/src/types/source/citation/data.rs
+++ b/src/types/source/citation/data.rs
@@ -44,10 +44,8 @@ impl Parser for SourceCitationData {
                 "DATE" => self.date = Some(Date::new(tokenizer, level + 1)?),
                 "TEXT" => self.text = Some(Text::new(tokenizer, level + 1)?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled SourceCitationData Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/source/text.rs
+++ b/src/types/source/text.rs
@@ -45,10 +45,8 @@ impl Parser for Text {
                     value.push_str(&tokenizer.take_line_value()?);
                 }
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Text Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
 

--- a/src/types/submission.rs
+++ b/src/types/submission.rs
@@ -115,10 +115,8 @@ impl Parser for Submission {
                 "SUBM" => self.submitter_ref = Some(tokenizer.take_line_value()?),
                 "TEMP" => self.temple_code = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Submission Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())

--- a/src/types/translation.rs
+++ b/src/types/translation.rs
@@ -44,10 +44,8 @@ impl Parser for Translation {
                 "MIME" => self.mime = Some(tokenizer.take_line_value()?),
                 "LANG" => self.language = Some(tokenizer.take_line_value()?),
                 _ => {
-                    return Err(GedcomError::ParseError {
-                        line: tokenizer.line,
-                        message: format!("Unhandled Translation Tag: {tag}"),
-                    })
+                    // Gracefully skip unknown tags
+                    tokenizer.take_line_value()?;
                 }
             }
             Ok(())


### PR DESCRIPTION
Resolves #48.

Within-record handlers now uniformly skip unknown standard-shaped tags instead of erroring in some records and skipping in others. Top-level dispatch (level-0 records) and lexical errors stay strict.

Configurable strictness is planned for a later release and is deliberately out of scope here — closes #49 in favor of this minimal, non-API-changing fix. Thanks to @Its-Just-Nans for flagging the inconsistency.