### PR TITLE
feat: add NOTE_RECORD from 5.5.5

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -625,9 +625,10 @@ impl Parser for GedcomData {
                     "SUBN" => self.add_submission(Submission::new(tokenizer, level, pointer)?),
                     "SUBM" => self.add_submitter(Submitter::new(tokenizer, level, pointer)?),
                     "OBJE" => self.add_multimedia(Multimedia::new(tokenizer, level, pointer)?),
-                    "NOTE" => self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?),
-                    // GEDCOM 7.0: Shared note record
-                    "SNOTE" => self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?),
+                    // GEDCOM 7.0: Shared note record SNOTE
+                    "NOTE" | "SNOTE" => {
+                        self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?)
+                    }
                     // Trailer is optional in the wild; allow EOF-terminated files.
                     "TRLR" => break,
                     _ => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -627,7 +627,7 @@ impl Parser for GedcomData {
                     "OBJE" => self.add_multimedia(Multimedia::new(tokenizer, level, pointer)?),
                     // GEDCOM 7.0: Shared note record SNOTE
                     "NOTE" | "SNOTE" => {
-                        self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?)
+                        self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?);
                     }
                     // Trailer is optional in the wild; allow EOF-terminated files.
                     "TRLR" => break,

--- a/src/types.rs
+++ b/src/types.rs
@@ -625,6 +625,7 @@ impl Parser for GedcomData {
                     "SUBN" => self.add_submission(Submission::new(tokenizer, level, pointer)?),
                     "SUBM" => self.add_submitter(Submitter::new(tokenizer, level, pointer)?),
                     "OBJE" => self.add_multimedia(Multimedia::new(tokenizer, level, pointer)?),
+                    "NOTE" => self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?),
                     // GEDCOM 7.0: Shared note record
                     "SNOTE" => self.add_shared_note(SharedNote::new(tokenizer, level, pointer)?),
                     // Trailer is optional in the wild; allow EOF-terminated files.


### PR DESCRIPTION
<img width="749" height="174" alt="image" src="https://github.com/user-attachments/assets/bec84916-26ea-430c-bb09-0c7a14912e50" />

SNOTE from GEDCOM 7 is handled but not the NOTE from 5.5.5