### PR TITLE
fix: distinguish xref pointers from free-text SOURCE_CITATION values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/types/individual.rs
+++ b/src/types/individual.rs
@@ -443,7 +443,7 @@ mod tests {
             sex.fact.as_ref().unwrap(),
             "A fact about an individual's gender"
         );
-        assert_eq!(sex.sources[0].xref, "@CITATION1@");
+        assert_eq!(sex.sources[0].source.as_xref(), Some("@CITATION1@"));
         assert_eq!(sex.sources[0].page.as_ref().unwrap(), "Page: 132");
     }
 

--- a/src/types/source.rs
+++ b/src/types/source.rs
@@ -183,7 +183,10 @@ mod tests {
         let mut ged = Gedcom::new(sample.chars()).unwrap();
         let data = ged.parse_data().unwrap();
 
-        assert_eq!(data.individuals[0].source[0].xref, "@SOURCE1@");
+        assert_eq!(
+            data.individuals[0].source[0].source.as_xref(),
+            Some("@SOURCE1@")
+        );
         assert_eq!(data.individuals[0].source[0].page.as_ref().unwrap(), "42");
     }
     #[test]

--- a/src/types/source/citation.rs
+++ b/src/types/source/citation.rs
@@ -16,13 +16,93 @@ use crate::{
     GedcomError,
 };
 
+/// What a `SOUR` line under a [`Citation`] refers to.
+///
+/// The GEDCOM 5.5.1 grammar defines `SOURCE_CITATION` as a union of two forms:
+///
+/// ```text
+/// n SOUR @<XREF:SOUR>@          {if the source is stored in a SOURCE_RECORD}
+/// n SOUR <SOURCE_DESCRIPTION>   {if the source is not stored in a SOURCE_RECORD}
+/// ```
+///
+/// Some exporters (e.g. Geneanet/GeneWeb) write a free-text description, such
+/// as a URL, instead of a pointer to a structured `Source` record. Without
+/// this distinction, callers can't tell a resolvable xref apart from a
+/// description that merely looks like one, which risks silently dropping the
+/// text when trying to resolve it as a pointer.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+pub enum CitationSource {
+    /// Pointer to a structured `Source` record, e.g. `@S1@`.
+    Xref(Xref),
+    /// Free-text source description, used when there is no structured `Source` record.
+    Description(String),
+}
+
+impl CitationSource {
+    /// Classifies a raw `SOUR` line value as an xref pointer or a free-text description.
+    ///
+    /// A value is treated as a pointer only if it is wrapped in a single pair
+    /// of `@` characters with no embedded whitespace or extra `@`, matching
+    /// the GEDCOM `POINTER` grammar (e.g. `@S1@`). Anything else, including
+    /// GEDCOM 7's `@VOID@`-adjacent free text or a URL, is a description.
+    #[must_use]
+    pub fn parse(value: String) -> Self {
+        if is_xref_pointer(&value) {
+            CitationSource::Xref(value)
+        } else {
+            CitationSource::Description(value)
+        }
+    }
+
+    /// Returns the xref if this citation points to a structured `Source` record.
+    #[must_use]
+    pub fn as_xref(&self) -> Option<&str> {
+        match self {
+            CitationSource::Xref(xref) => Some(xref),
+            CitationSource::Description(_) => None,
+        }
+    }
+
+    /// Returns the free-text description, if this citation has no structured `Source` record.
+    #[must_use]
+    pub fn as_description(&self) -> Option<&str> {
+        match self {
+            CitationSource::Description(description) => Some(description),
+            CitationSource::Xref(_) => None,
+        }
+    }
+
+    /// Returns the underlying string value, regardless of variant.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        match self {
+            CitationSource::Xref(value) | CitationSource::Description(value) => value,
+        }
+    }
+}
+
+/// Returns true if `value` matches the GEDCOM `POINTER` grammar: a single
+/// leading and trailing `@`, non-empty in between, with no embedded
+/// whitespace or additional `@` characters.
+fn is_xref_pointer(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0] == b'@'
+        && bytes[bytes.len() - 1] == b'@'
+        && value[1..value.len() - 1]
+            .bytes()
+            .all(|b| b != b'@' && !b.is_ascii_whitespace())
+}
+
 /// The data provided in the `SourceCitation` structure is source-related information specific to
 /// the data being cited. (See GEDCOM 5.5 Specification page 39.)
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct Citation {
-    /// Reference to the `Source`
-    pub xref: Xref,
+    /// What this citation refers to: a structured `Source` record (xref) or
+    /// a free-text description.
+    pub source: CitationSource,
     /// Page number of source
     pub page: Option<String>,
     pub data: Option<SourceCitationData>,
@@ -50,7 +130,7 @@ impl Citation {
     /// This function will return an error if parsing fails.
     pub fn new(tokenizer: &mut Tokenizer<'_>, level: u8) -> Result<Citation, GedcomError> {
         let mut citation = Citation {
-            xref: tokenizer.take_line_value()?,
+            source: CitationSource::parse(tokenizer.take_line_value()?),
             page: None,
             data: None,
             note: None,
@@ -141,9 +221,38 @@ mod tests {
         let birt = &indi.events[0];
         let sour = &birt.citations[0];
 
-        assert_eq!(sour.xref, "@S1@");
+        assert_eq!(sour.source.as_xref(), Some("@S1@"));
         assert_eq!(sour.page.as_ref().unwrap(), "Page 42");
         assert_eq!(sour.event_type.as_ref().unwrap(), "BIRT");
         assert_eq!(sour.role.as_ref().unwrap(), "CHIL");
+    }
+
+    #[test]
+    fn test_parse_source_citation_with_free_text_description() {
+        // Geneanet/GeneWeb-style export: a SOUR citation with a free-text
+        // description (e.g. a URL) instead of a pointer to a SOUR record.
+        let sample = "\
+            0 HEAD\n\
+            1 GEDC\n\
+            2 VERS 5.5.1\n\
+            0 @I1@ INDI\n\
+            1 NAME John /Doe/\n\
+            1 BIRT\n\
+            2 DATE 1 JAN 1900\n\
+            2 SOUR https://example.com/records/123\n\
+            0 TRLR";
+
+        let mut doc = Gedcom::new(sample.chars()).unwrap();
+        let data = doc.parse_data().unwrap();
+
+        let indi = &data.individuals[0];
+        let birt = &indi.events[0];
+        let sour = &birt.citations[0];
+
+        assert_eq!(
+            sour.source.as_description(),
+            Some("https://example.com/records/123")
+        );
+        assert_eq!(sour.source.as_xref(), None);
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -872,7 +872,7 @@ impl GedcomWriter {
         level: u8,
         citation: &Citation,
     ) -> Result<(), io::Error> {
-        self.write_line(writer, level, "SOUR", Some(&citation.xref))?;
+        self.write_line(writer, level, "SOUR", Some(citation.source.value()))?;
 
         if let Some(ref page) = citation.page {
             self.write_value_or_wrap(writer, level + 1, "PAGE", Some(page))?;

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -176,6 +176,39 @@ fn test_round_trip_source() {
 }
 
 #[test]
+fn test_round_trip_citation_with_free_text_description() {
+    // Geneanet/GeneWeb-style export: a SOUR citation with a free-text
+    // description (e.g. a URL) instead of a pointer to a SOUR record. This
+    // must survive a write/re-parse cycle instead of being dropped or
+    // misread as an unresolved xref.
+    let original = r#"0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @I1@ INDI
+1 NAME John /Doe/
+1 BIRT
+2 DATE 1 JAN 1900
+2 SOUR https://example.com/records/123
+0 TRLR"#;
+
+    let data1 = GedcomBuilder::new().build_from_str(original).unwrap();
+
+    let writer = GedcomWriter::new();
+    let written = writer.write_to_string(&data1).unwrap();
+
+    let data2 = GedcomBuilder::new().build_from_str(&written).unwrap();
+
+    let citation1 = &data1.individuals[0].events[0].citations[0];
+    let citation2 = &data2.individuals[0].events[0].citations[0];
+
+    assert_eq!(
+        citation1.source.as_description(),
+        Some("https://example.com/records/123")
+    );
+    assert_eq!(citation1.source, citation2.source);
+}
+
+#[test]
 fn test_round_trip_repository() {
     let original = r#"0 HEAD
 1 GEDC


### PR DESCRIPTION
GEDCOM 5.5.1's SOURCE_CITATION grammar is a union of two forms:

    n SOUR @<XREF:SOUR>@          {if the source is stored in a SOURCE_RECORD}
    n SOUR <SOURCE_DESCRIPTION>   {if the source is not stored in a SOURCE_RECORD}

`Citation` only modeled the first branch: its `xref` field was a bare `String` (itself just `type Xref = String`), filled directly from the raw line value with no check for which form was actually present. Exporters that legitimately use the free-text form (e.g. Geneanet/GeneWeb writing a URL instead of a `@S1@` pointer) would end up with that text sitting in a field named `xref`, indistinguishable from a real pointer. Consumers that resolve `xref` against known `Source` records fail to find a match and silently drop the citation, losing real data on a valid GEDCOM file.

Replace the field with `source: CitationSource`, an enum with `Xref(Xref)` and `Description(String)` variants. `CitationSource::parse` classifies the raw line value using the GEDCOM `POINTER` grammar (wrapped in a single pair of `@`, no embedded whitespace or extra `@`); anything else is treated as a description. `as_xref()`/`as_description()`/`value()` give callers a way to tell the two apart, or fall back to the raw string when they don't care.

This is a breaking change to `Citation`'s public field.