### PR TITLE
fix(writer): name nick type & name's type sub-tag

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -412,6 +412,10 @@ impl GedcomWriter {
     fn write_name<W: Write>(&self, writer: &mut W, name: &Name) -> Result<(), io::Error> {
         self.write_value_or_wrap(writer, 1, "NAME", name.value.as_deref())?;
 
+        if let Some(ref name_type) = name.name_type {
+            self.write_value_or_wrap(writer, 2, "TYPE", Some(name_type.as_str()))?;
+        }
+
         if let Some(ref given) = name.given {
             self.write_value_or_wrap(writer, 2, "GIVN", Some(given))?;
         }
@@ -1487,6 +1491,18 @@ mod tests {
         let output = writer.write_to_string(&data).unwrap();
 
         assert!(output.contains("2 NICK Johnny"));
+    }
+
+    #[test]
+    fn test_write_name_type() {
+        let source =
+            "0 HEAD\n1 GEDC\n2 VERS 5.5\n0 @I1@ INDI\n1 NAME John /Doe/\n2 TYPE MARRIED\n0 TRLR";
+        let data = GedcomBuilder::new().build_from_str(source).unwrap();
+
+        let writer = GedcomWriter::new();
+        let output = writer.write_to_string(&data).unwrap();
+
+        assert!(output.contains("2 TYPE MARRIED"));
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -416,6 +416,10 @@ impl GedcomWriter {
             self.write_value_or_wrap(writer, 2, "GIVN", Some(given))?;
         }
 
+        if let Some(ref nickname) = name.nickname {
+            self.write_value_or_wrap(writer, 2, "NICK", Some(nickname))?;
+        }
+
         if let Some(ref surname) = name.surname {
             self.write_value_or_wrap(writer, 2, "SURN", Some(surname))?;
         }
@@ -1471,6 +1475,18 @@ mod tests {
         assert_eq!(data.individuals.len(), data2.individuals.len());
         assert_eq!(data.individuals[0].xref, data2.individuals[0].xref);
         assert_eq!(data.individuals[0].name, data2.individuals[0].name);
+    }
+
+    #[test]
+    fn test_write_name_nickname() {
+        let source =
+            "0 HEAD\n1 GEDC\n2 VERS 5.5\n0 @I1@ INDI\n1 NAME John /Doe/\n2 NICK Johnny\n0 TRLR";
+        let data = GedcomBuilder::new().build_from_str(source).unwrap();
+
+        let writer = GedcomWriter::new();
+        let output = writer.write_to_string(&data).unwrap();
+
+        assert!(output.contains("2 NICK Johnny"));
     }
 
     #[test]


### PR DESCRIPTION
**Emit NICK sub-tag when writing NAME**
write_name() serializes every other PERSONAL_NAME_PIECES sub-tag
(GIVN, SURN, NPFX, NSFX, SPFX) plus SOUR citations and NOTE, but had
no branch for NICK. As a result, Name.nickname was silently dropped
on every write and on round-trip (parse -> write -> parse), even
though Name::parse() reads the NICK tag back correctly.

Add the missing branch, writing "NICK <value>" right after GIVN, and
add a regression test asserting the tag survives a round trip.

**Emit NAME's TYPE sub-tag**
Name.name_type (tag: TYPE) records what kind of name this is (birth,
married, aka, professional, etc.), and Name::parse() reads it back
via NameType::parse(). write_name() had no corresponding branch,
though, so the classification was silently discarded on every write
and lost across a round trip.

Emit "TYPE <value>" via NameType::as_str() right after the NAME line,
matching the GEDCOM spec's PERSONAL_NAME_STRUCTURE ordering (TYPE
comes before the name pieces). Add a regression test covering the
round trip.